### PR TITLE
[opus] Update `opusic-sys` and expose bundling options

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ keywords = ["audio", "codec", "symphonia", "aac", "opus"]
 
 [workspace.dependencies]
 fdk-aac = "0.8"
-opusic-sys = "0.5.8"
+opusic-sys = { version = "0.5.8", default-features = false }
 symphonia-core = "0.5.4"
 log = "0.4.28"
 

--- a/crates/symphonia-adapter-libopus/Cargo.toml
+++ b/crates/symphonia-adapter-libopus/Cargo.toml
@@ -16,6 +16,10 @@ keywords.workspace = true
 opusic-sys = { workspace = true }
 symphonia-core = { workspace = true }
 
+[features]
+default = ["bundled"]
+bundled = ["opusic-sys/bundled"]
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/crates/symphonia-adapter-libopus/README.md
+++ b/crates/symphonia-adapter-libopus/README.md
@@ -28,6 +28,12 @@ codec_registry.register_all::<OpusDecoder>();
 // use codec_registry created above instead of symphonia::default::get_codecs();
 ```
 
+## Linking & Bundling
+
+By default `libopus` will be compiled and bundled into the resulting binary.
+
+To disable this, set `default-features = false`. Or to explicitly enable bundling add feature `bundled`.
+
 ## License
 
 This crate is licensed under either the MIT and Apache 2.0 license, at your


### PR DESCRIPTION
This PR updates `opusic-sys` to `0.5.8` which got new bundling options.
Additionally, expose those bundling options.

Before 0.5.8, to dynamically link, it was required to set the custom environment variable `OPUS_LIB_DIR`, with this new version, this can still be used as a override, but not required anymore (and let the linker find the correct library from PATH). The new version also gained a new option to force only bundling. (as a side-note, it also gained `OPUS_LIB_STATIC` to static-link, but not compile)