### PR TITLE
Use f32 internally instead of i16.

### DIFF
--- a/crates/symphonia-adapter-libopus/src/decoder.rs
+++ b/crates/symphonia-adapter-libopus/src/decoder.rs
@@ -33,13 +33,13 @@ impl Decoder {
         Ok(Self { ptr, channels })
     }
 
-    pub(crate) fn decode(&mut self, input: &[u8], output: &mut [i16]) -> Result<usize> {
+    pub(crate) fn decode(&mut self, input: &[u8], output: &mut [f32]) -> Result<usize> {
         let ptr = match input.len() {
             0 => std::ptr::null(),
             _ => input.as_ptr(),
         };
         let len = unsafe {
-            opusic_sys::opus_decode(
+            opusic_sys::opus_decode_float(
                 self.ptr,
                 ptr,
                 len(input),

--- a/crates/symphonia-adapter-libopus/src/lib.rs
+++ b/crates/symphonia-adapter-libopus/src/lib.rs
@@ -28,8 +28,8 @@ const DEFAULT_SAMPLE_RATE: usize = 48000;
 pub struct OpusDecoder {
     params: CodecParameters,
     decoder: Decoder,
-    buf: AudioBuffer<i16>,
-    pcm: [i16; MAX_SAMPLES_PER_CHANNEL * 2],
+    buf: AudioBuffer<f32>,
+    pcm: [f32; MAX_SAMPLES_PER_CHANNEL * 2],
     samples_per_channel: usize,
     sample_rate: u32,
     num_channels: usize,
@@ -107,7 +107,7 @@ impl codecs::Decoder for OpusDecoder {
                 DEFAULT_SAMPLES_PER_CHANNEL as u64,
                 num_channels,
             ),
-            pcm: [0; _],
+            pcm: [0.0; _],
             samples_per_channel: DEFAULT_SAMPLES_PER_CHANNEL,
             sample_rate,
             num_channels,
@@ -194,7 +194,7 @@ fn audio_buffer(
     sample_rate: u32,
     samples_per_channel: u64,
     num_channels: usize,
-) -> AudioBuffer<i16> {
+) -> AudioBuffer<f32> {
     let channels = map_to_channels(num_channels).expect("invalid channels");
     let spec = SignalSpec::new(sample_rate, channels);
     AudioBuffer::new(samples_per_channel, spec)


### PR DESCRIPTION
Most of my opus files are f32, however, the adapter always converts to i16. The symphonia vorbis implementation always converts to f32 already, so for consistency (and quality), using f32 instead of i16 likely makes sense.